### PR TITLE
Refactor: Register signal handlers in main thread only

### DIFF
--- a/apps/zero_dte/zero_dte_app.py
+++ b/apps/zero_dte/zero_dte_app.py
@@ -189,8 +189,6 @@ def handle_signal(signum, frame):
     logging.info("Received signal %s; shutting down gracefully...", signum)
     type_shutdown.set()
 
-signal.signal(signal.SIGINT, handle_signal)
-signal.signal(signal.SIGTERM, handle_signal)
 
 class Settings(BaseSettings):
     
@@ -993,6 +991,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
     strategy = args.strategy
     auto_reenter = args.auto_reenter
+    # Register signal handlers in main thread
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
 
     # Outer loop: run trading cycles for each day
     while True:


### PR DESCRIPTION
### Summary

Move the `signal.signal()` registrations into the `__main__` block so they're only invoked when the script is running as the main thread. This prevents the `ValueError: signal only works in main thread of the main interpreter` when importing modules in worker threads.

### Changes
- Removed global `signal.signal()` calls during module import.
- Added `signal.signal(...)` registrations immediately after parsing CLI arguments in `__main__`.

### Related Issues
- Fixes issue where background threads trigger `ValueError` on import.

### Testing
- Verified that importing `two_phase` no longer raises a signal registration error.
- Manually ran the bot locally; worker threads start without exception.

<!-- If there's a related issue, link it here -->
