### PR TITLE
Zero-DTE: Condor PnL Monitoring, Config Hardenings, and Tests

### DIFF
--- a/tests/test_strangle_app.py
+++ b/tests/test_strangle_app.py
@@ -86,6 +86,166 @@ def test_monitor_and_exit_strangle(monkeypatch):
     # simulate prices that meet target immediately
     prices = [2.0, 1.0]
 
+
+
+def test_run_strangle_sizing_capped(monkeypatch):
+    """
+    Test that run_strangle caps the quantity based on RISK_PCT_PER_TRADE and STOP_LOSS_PCT.
+    Equity=1000, prices sum=20, STOP_LOSS_PCT=0.20 → risk_per_contract=4.0, allowed_risk=1000*0.01=10 → max_contracts=2
+    Original qty=5 → capped to 2
+    """
+    from datetime import time as dt_time
+    # Mock choose_otm_strangle_contracts
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.choose_otm_strangle_contracts",
+        lambda trading, stock_client, symbol: ("C1", "P1"),
+    )
+    # Mock account equity
+    class FakeAccount:
+        equity = "1000"
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.TradingClient.get_account",
+        lambda self: FakeAccount(),
+    )
+    # Mock option latest trade prices
+    class FakeTrade:
+        def __init__(self, price):
+            self.price = price
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.OptionHistoricalDataClient.get_option_latest_trade",
+        lambda self, req: {"C1": FakeTrade(10.0), "P1": FakeTrade(10.0)},
+    )
+    # Capture submitted qty
+    submitted = {}
+    def fake_submit(trading, call_sym, put_sym, qty):
+        submitted['qty'] = qty
+        class DummyResp:
+            legs = []
+        return DummyResp()
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.submit_strangle",
+        fake_submit,
+    )
+    # Skip monitoring and exit
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.monitor_and_exit_strangle",
+        lambda *args, **kwargs: 0.0,
+    )
+    # Run with original qty greater than max_contracts
+    from apps.zero_dte.zero_dte_app import run_strangle
+    result = run_strangle(
+        trading=None,
+        stock_client=None,
+        option_client=None,
+        symbol="SYM",
+        qty=5,
+        target_pct=0.5,
+        poll_interval=0.01,
+        exit_cutoff=dt_time(23, 59),
+    )
+    assert submitted.get('qty') == 2, f"Expected qty capped to 2, got {submitted.get('qty')}"
+
+
+def test_run_strangle_sizing_no_cap(monkeypatch):
+    """
+    Test that run_strangle does not reduce qty when max_contracts exceeds original qty.
+    Equity=1000, prices sum=2, STOP_LOSS_PCT=0.20 → risk_per_contract=0.4, allowed_risk=1000*0.01=10 → max_contracts=25
+    Original qty=5 → remains 5
+    """
+    from datetime import time as dt_time
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.choose_otm_strangle_contracts",
+        lambda trading, stock_client, symbol: ("C1", "P1"),
+    )
+    class FakeAccount:
+        equity = "1000"
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.TradingClient.get_account",
+        lambda self: FakeAccount(),
+    )
+    class FakeTrade:
+        def __init__(self, price):
+            self.price = price
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.OptionHistoricalDataClient.get_option_latest_trade",
+        lambda self, req: {"C1": FakeTrade(1.0), "P1": FakeTrade(1.0)},
+    )
+    submitted = {}
+    def fake_submit(trading, call_sym, put_sym, qty):
+        submitted['qty'] = qty
+        class DummyResp:
+            legs = []
+        return DummyResp()
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.submit_strangle",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.monitor_and_exit_strangle",
+        lambda *args, **kwargs: 0.0,
+    )
+    from apps.zero_dte.zero_dte_app import run_strangle
+    result = run_strangle(
+        trading=None,
+        stock_client=None,
+        option_client=None,
+        symbol="SYM",
+        qty=5,
+        target_pct=0.5,
+        poll_interval=0.01,
+        exit_cutoff=dt_time(23, 59),
+    )
+    assert submitted.get('qty') == 5, f"Expected qty unchanged at 5, got {submitted.get('qty')}"
+
+
+def test_run_strangle_sizing_skip(monkeypatch):
+    """
+    Test that run_strangle skips the trade when risk budget yields qty < 1.
+    Equity=100, prices sum=200, STOP_LOSS_PCT=0.20 → risk_per_contract=40, allowed_risk=100*0.01=1 → max_contracts=0 -> skip
+    """
+    from datetime import time as dt_time
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.choose_otm_strangle_contracts",
+        lambda trading, stock_client, symbol: ("C1", "P1"),
+    )
+    class FakeAccount:
+        equity = "100"
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.TradingClient.get_account",
+        lambda self: FakeAccount(),
+    )
+    class FakeTrade:
+        def __init__(self, price):
+            self.price = price
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.OptionHistoricalDataClient.get_option_latest_trade",
+        lambda self, req: {"C1": FakeTrade(100.0), "P1": FakeTrade(100.0)},
+    )
+    # Capture if submit_strangle is called
+    called = {'invoked': False}
+    def fake_submit(trading, call_sym, put_sym, qty):
+        called['invoked'] = True
+        class DummyResp:
+            legs = []
+        return DummyResp()
+    monkeypatch.setattr(
+        "apps.zero_dte.zero_dte_app.submit_strangle",
+        fake_submit,
+    )
+    from apps.zero_dte.zero_dte_app import run_strangle
+    result = run_strangle(
+        trading=None,
+        stock_client=None,
+        option_client=None,
+        symbol="SYM",
+        qty=5,
+        target_pct=0.5,
+        poll_interval=0.01,
+        exit_cutoff=dt_time(23, 59),
+    )
+    assert not called['invoked'], "Expected skip of submit_strangle when qty < 1"
+    assert result is None, "Expected run_strangle to return None when skipping trade"
+
     def fake_trade(self, req):
         p = prices.pop(0)
         return {"C1": DummyTrade(p), "P1": DummyTrade(p)}


### PR DESCRIPTION
This PR implements comprehensive fixes and enhancements for the two-phase (condor) monitor and related workflows:

1. Condor Monitor Updates:
   - Compute per-tick PnL (`entry_credit - current_credit`) and accumulate in `condor_pnl_history`.
   - Add INFO-level "Exit PnL=±X.XX" logging upon exit.
   - Return boolean flag indicating profit exit (True) or not (False).
   - Harden emergency and daily profit shutdowns with logging and `type_shutdown`.
   - Nicely handle position sizing on exit by fetching actual fills and capping exit quantity.

2. Strangle Monitor Updates:
   - Fetch final option prices post-exit to compute actual PnL.
   - Log "Exit PnL=±X.XX" and return numeric PnL to wrapper.

3. Wrapper (`_execute_trade_and_update`) now casts monitor returns to `float` and updates `daily_pnl` accordingly.

4. Log Analysis (`analyze_logs_for_date`) path fix to read from `apps/logs` and parse "Exit PnL" entries.

5. Configuration Hardenings:
   - Lower default STOP_LOSS_PCT for condors (10–15%) via .env defaults.
   - Introduce `MAX_LOSS_PER_TRADE` setting.
   - Adjust `RISK_PCT_PER_TRADE` default to prevent oversized positions.

6. Unit Tests:
   - New pytest tests for `monitor_and_exit_condor` retry, profit, and stop-loss behaviors.
   - Extended strangle tests to verify PnL calculation and quantity capping in `run_strangle`.

Closes #<issue-number>  (if applicable)

Please review the logic, especially PnL computations and log directory adjustments, and let me know if any tweaks are needed.