### PR TITLE
Phase-1: Day-Type Classifier – unit tests + gap-logic fixes

### DIFF
--- a/apps/zero_dte/market_structure.py
+++ b/apps/zero_dte/market_structure.py
@@ -1,0 +1,199 @@
+"""Market-structure / day-type classification & strategy routing (Phase-1).
+
+This module is intentionally lightweight: it introduces only *types* and a
+stub `classify_day()` implementation so that other parts of the bot can start
+wiring against the public interface while the statistical logic is filled in
+later iterations.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, time as dt_time, timedelta
+from enum import StrEnum
+from typing import Mapping
+
+import pandas as pd
+from alpaca.data.historical import StockHistoricalDataClient, OptionHistoricalDataClient
+from alpaca.data.timeframe import TimeFrame
+
+from .data import get_stock_bars
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public enums (importable by the rest of the bot)
+# ---------------------------------------------------------------------------
+
+
+class DayType(StrEnum):
+    """High-level intraday market regimes recognised by the bot."""
+
+    GAP_GO = "GAP_GO"  # gaps and continues in same direction
+    GAP_TRAP = "GAP_TRAP"  # gaps then fully retraces / reverses
+    TREND_UP = "TREND_UP"  # steady intraday up-trend
+    TREND_DOWN = "TREND_DOWN"  # steady intraday down-trend
+    INSIDE = "INSIDE"  # session stays within yesterday's range
+    RANGE = "RANGE"  # whipsaw / low-trend day inside a wide range
+    EVENT_RISK_HIGH_IV_CRUSH = "EVENT_RISK_HIGH_IV_CRUSH"  # macro event then vol crush
+    UNCLASSIFIED = "UNCLASSIFIED"  # fallback / unknown
+
+
+class StrategyID(StrEnum):
+    """Abstract identifiers understood by trade-builder layer."""
+
+    SKEWED_CREDIT_PUT = "SKEWED_CREDIT_PUT"
+    SKEWED_CREDIT_CALL = "SKEWED_CREDIT_CALL"
+    REVERSAL_SPREAD = "REVERSAL_SPREAD"
+    DIRECTIONAL_DEBIT_VERTICAL = "DIRECTIONAL_DEBIT_VERTICAL"
+    TIGHT_IRON_CONDOR = "TIGHT_IRON_CONDOR"
+    WIDE_IRON_CONDOR = "WIDE_IRON_CONDOR"
+    PRE_EVENT_CONDOR = "PRE_EVENT_CONDOR"
+    SYMMETRIC_STRANGLE = "SYMMETRIC_STRANGLE"
+
+
+# ---------------------------------------------------------------------------
+# Strategy selector – configurable mapping DayType → StrategyID
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_MAP: Mapping[DayType, StrategyID] = {
+    DayType.GAP_GO: StrategyID.SKEWED_CREDIT_PUT,  # or CALL if bearish – builder decides
+    DayType.GAP_TRAP: StrategyID.REVERSAL_SPREAD,
+    DayType.TREND_UP: StrategyID.DIRECTIONAL_DEBIT_VERTICAL,
+    DayType.TREND_DOWN: StrategyID.DIRECTIONAL_DEBIT_VERTICAL,
+    DayType.INSIDE: StrategyID.TIGHT_IRON_CONDOR,
+    DayType.RANGE: StrategyID.WIDE_IRON_CONDOR,
+    DayType.EVENT_RISK_HIGH_IV_CRUSH: StrategyID.PRE_EVENT_CONDOR,
+    DayType.UNCLASSIFIED: StrategyID.SYMMETRIC_STRANGLE,
+}
+
+
+@dataclass(slots=True)
+class StrategySelector:
+    """Return the *StrategyID* for a given *DayType*.
+
+    The mapping can be overridden via *mapping* (e.g. parsed from YAML).
+    """
+
+    mapping: Mapping[DayType, StrategyID] = field(default_factory=lambda: _DEFAULT_MAP.copy())
+
+    def strategy_for_day(self, day_type: DayType) -> StrategyID:
+        return self.mapping.get(day_type, StrategyID.SYMMETRIC_STRANGLE)
+
+
+# ---------------------------------------------------------------------------
+# Day-type classifier
+# ---------------------------------------------------------------------------
+
+
+def classify_day(
+    symbol: str,
+    stock_client: StockHistoricalDataClient,
+    option_client: OptionHistoricalDataClient | None = None,
+    cfg: dict | None = None,
+) -> DayType:
+    """Heuristic classification of the current session type.
+
+    Parameters
+    ----------
+    symbol
+        Underlying equity ticker (e.g. "SPY").
+    stock_client / option_client
+        Authenticated Alpaca data clients, reused to avoid extra handshakes.
+    cfg
+        Optional dict of thresholds (gap %, ATR lookback, IV rank bounds, etc.).
+
+    Notes
+    -----
+    For Phase-1 this implementation is *minimal* – the function demonstrates
+    the expected signature and produces a deterministic yet naive result to
+    keep the bot operational while we iterate on richer metrics.
+    """
+
+    if cfg is None:
+        cfg = {}
+
+    today = cfg.get("today", date.today())
+    log.debug("Classifying day-type for %s on %s", symbol, today)
+
+    # ------------------------------------------------------------------
+    # 0. Calendar override – macro / earnings days → event-risk type
+    # ------------------------------------------------------------------
+    cal_path = cfg.get("econ_calendar_path", "apps/zero_dte/data/econ_calendar.yaml")
+    try:
+        import yaml  # local dep only
+        with open(cal_path) as fh:
+            _CAL = yaml.safe_load(fh) or {}
+        if today.isoformat() in _CAL:
+            return DayType.EVENT_RISK_HIGH_IV_CRUSH
+    except FileNotFoundError:
+        pass  # silently ignore missing calendar file
+    except Exception as exc:  # pragma: no cover
+        log.debug("Error reading econ-calendar YAML: %s", exc)
+
+    # ------------------------------------------------------------------
+    # 1. Retrieve yesterday + today minute bars
+    # ------------------------------------------------------------------
+    try:
+        bars_today = get_stock_bars(symbol, today, timeframe=TimeFrame.Minute)
+        bars_yday = get_stock_bars(symbol, today - timedelta(days=1), timeframe=TimeFrame.Minute)
+    except Exception as exc:  # pragma: no cover – defensive
+        log.warning("Cannot download bars – marking UNCLASSIFIED: %s", exc)
+        return DayType.UNCLASSIFIED
+
+    if bars_today.empty or bars_yday.empty:
+        return DayType.UNCLASSIFIED
+
+    # Gap size (%)
+    open_today = bars_today.iloc[0].open
+    close_yday = bars_yday.iloc[-1].close
+    gap_pct = (open_today - close_yday) / close_yday * 100
+    prev_high = bars_yday.high.max()
+    prev_low = bars_yday.low.min()
+
+    gap_outside = open_today > prev_high or open_today < prev_low
+
+    # Simple thresholds (configurable)
+    gap_thr = cfg.get("gap_pct_threshold", 0.4)
+    retrace_thr = cfg.get("gap_retrace_threshold", 50.0)  # % of gap
+
+    # Track running high/low to ~10:00 for retrace check
+    cutoff_naive = datetime.combine(today, dt_time(hour=10, minute=0))
+    cutoff = bars_today.index.tz.localize(cutoff_naive)
+    sub = bars_today[bars_today.index <= cutoff]
+
+    gap_filled = (
+        (sub.low.min() <= close_yday <= sub.high.max())  # touched prev close
+        if gap_pct > 0  # up-gap
+        else (sub.high.max() >= close_yday >= sub.low.min())
+    )
+
+    # ------------------------------------------------------------------
+    # Decision tree (very rough – will be improved later)
+    # ------------------------------------------------------------------
+    if gap_outside and abs(gap_pct) > gap_thr:
+        if gap_filled:
+            return DayType.GAP_TRAP
+        return DayType.GAP_GO
+
+    # Trend determination via simple slope of VWAP 09:30-12:00
+    noon_naive = datetime.combine(today, dt_time(hour=12))
+    noon_cut = bars_today.index.tz.localize(noon_naive)
+    vwap = (bars_today.close * bars_today.volume).cumsum() / bars_today.volume.cumsum()
+    early = vwap[bars_today.index <= noon_cut]
+    if len(early) < 2:
+        return DayType.INSIDE  # not enough data – default calm
+    slope = early.iloc[-1] - early.iloc[0]
+
+    if slope > 0.2:  # ~0.2$ early slope ⇒ uptrend
+        return DayType.TREND_UP
+    if slope < -0.2:
+        return DayType.TREND_DOWN
+
+    # Inside day if today range within y-day range
+    if (bars_today.high.max() <= bars_yday.high.max()) and (bars_today.low.min() >= bars_yday.low.min()):
+        return DayType.INSIDE
+
+    return DayType.UNCLASSIFIED

--- a/tests/test_market_structure.py
+++ b/tests/test_market_structure.py
@@ -1,0 +1,79 @@
+import pandas as pd
+from datetime import date, timedelta
+
+from apps.zero_dte.market_structure import classify_day, DayType
+
+
+def _make_bars(prices, day):
+    idx = pd.date_range(start=f"{day} 09:30", periods=len(prices), freq="T", tz="US/Eastern")
+    return pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices,
+            "low": prices,
+            "close": prices,
+            "volume": [100] * len(prices),
+        },
+        index=idx,
+    )
+
+
+def _patch(monkeypatch, today_df, yday_df):
+    def fake_get_stock_bars(symbol, bar_date, timeframe=None):
+        if bar_date == today_df.index[0].date():
+            return today_df
+        return yday_df
+
+    monkeypatch.setattr(
+        "apps.zero_dte.market_structure.get_stock_bars", fake_get_stock_bars, raising=True
+    )
+
+
+def test_gap_go(monkeypatch):
+    today = date(2025, 6, 23)
+    yday = today - timedelta(days=1)
+    bars_today = _make_bars([110] * 30, today)
+    bars_yday = _make_bars([100] * 30, yday)
+
+    _patch(monkeypatch, bars_today, bars_yday)
+
+    dt = classify_day("TEST", stock_client=None, cfg={"today": today})
+    assert dt == DayType.GAP_GO
+
+
+def test_gap_trap(monkeypatch):
+    today = date(2025, 6, 24)
+    yday = today - timedelta(days=1)
+    # price touches 100 (fills gap)
+    bars_today = _make_bars([110, 109, 100, 102, 104] + [105] * 25, today)
+    bars_yday = _make_bars([100] * 30, yday)
+
+    _patch(monkeypatch, bars_today, bars_yday)
+
+    dt = classify_day("TEST", stock_client=None, cfg={"today": today})
+    assert dt == DayType.GAP_TRAP
+
+
+def test_trend_up(monkeypatch):
+    today = date(2025, 6, 25)
+    yday = today - timedelta(days=1)
+    # slight up-gap under threshold
+    bars_today = _make_bars(list(range(100, 131)), today)  # +30 bucks over 30 min
+    bars_yday = _make_bars([99] * 30, yday)
+
+    _patch(monkeypatch, bars_today, bars_yday)
+
+    dt = classify_day("TEST", stock_client=None, cfg={"gap_pct_threshold": 2.0, "today": today})
+    assert dt == DayType.TREND_UP
+
+
+def test_inside(monkeypatch):
+    today = date(2025, 6, 26)
+    yday = today - timedelta(days=1)
+    bars_today = _make_bars([100] * 30, today)  # flat inside
+    bars_yday = _make_bars([110] * 10 + [90] * 20, yday)
+
+    _patch(monkeypatch, bars_today, bars_yday)
+
+    dt = classify_day("TEST", stock_client=None, cfg={"today": today})
+    assert dt == DayType.INSIDE


### PR DESCRIPTION
## Summary
Adds deterministic unit-tests for the new *day-type* classifier and tightens gap/outside-day logic.

### ✨ What’s New
* **`tests/test_market_structure.py`** – 4 tests (GAP_GO, GAP_TRAP, TREND_UP, INSIDE) using synthetic minute bars.
* **Classifier improvements**
  * `today` override for tests.
  * Safe `default_factory` for `StrategySelector` mapping.
  * Proper timezone localisation (no −04:56 artifacts).
  * Guard against empty VWAP slice.
  * `gap_outside` check prevents false GAP_GO on inside days.

### ✅ Verification
```
pytest -q tests/test_market_structure.py  # 4 passed
pytest -q                                 # all 255 tests green
```

### Next Steps (Phase-1)
- YAML-driven thresholds & strategy mapping.
- Builder routing for non-strangle strategies.
- CLI flag `--day-type-debug` + docs.

> No breaking API changes. Ready for review.