### PR TITLE
feat: loop strategy during market hours

### DIFF
--- a/MKTONE/src/bot.py
+++ b/MKTONE/src/bot.py
@@ -1,6 +1,7 @@
 """Entry point for running the MKTONE bot."""
 
 import logging
+import time
 from pathlib import Path
 
 from .config import get_trading_client, get_stock_client
@@ -14,11 +15,18 @@ logging.basicConfig(
 )
 
 
-def main() -> None:
+def main(poll_interval: float = 60) -> None:
     trading = get_trading_client()
     stock = get_stock_client()
     strategy = ZeroDTECreditSpread(trading_client=trading, stock_client=stock)
-    strategy.run()
+
+    while True:
+        clock = trading.get_clock()
+        if not clock.is_open:
+            break
+        if not trading.get_all_positions():
+            strategy.run()
+        time.sleep(poll_interval)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/MKTONE/tests/test_bot_loop.py
+++ b/MKTONE/tests/test_bot_loop.py
@@ -1,0 +1,60 @@
+"""Tests for the bot loop respecting market hours and positions."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+# Ensure the src package is on the path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT.parent)])
+
+import src.bot as bot  # noqa: E402  # pylint: disable=C0413
+
+
+def test_loop_honors_market_hours(monkeypatch):
+    """Strategy should run only while the market is open."""
+    trading = Mock()
+    trading.get_clock = Mock(
+        side_effect=[SimpleNamespace(is_open=True), SimpleNamespace(is_open=False)]
+    )
+    trading.get_all_positions = Mock(return_value=[])
+    strategy = Mock()
+
+    monkeypatch.setattr(bot, "get_trading_client", lambda: trading)
+    monkeypatch.setattr(bot, "get_stock_client", Mock())
+    monkeypatch.setattr(
+        bot, "ZeroDTECreditSpread", lambda trading_client, stock_client: strategy
+    )
+    monkeypatch.setattr(bot.time, "sleep", lambda x: None)
+
+    bot.main(poll_interval=0)
+
+    assert strategy.run.call_count == 1
+    assert trading.get_clock.call_count == 2
+
+
+def test_loop_no_duplicate_positions(monkeypatch):
+    """Strategy should not run again when positions remain open."""
+    trading = Mock()
+    trading.get_clock = Mock(
+        side_effect=[
+            SimpleNamespace(is_open=True),
+            SimpleNamespace(is_open=True),
+            SimpleNamespace(is_open=False),
+        ]
+    )
+    trading.get_all_positions = Mock(side_effect=[[], ["existing"]])
+    strategy = Mock()
+
+    monkeypatch.setattr(bot, "get_trading_client", lambda: trading)
+    monkeypatch.setattr(bot, "get_stock_client", Mock())
+    monkeypatch.setattr(
+        bot, "ZeroDTECreditSpread", lambda trading_client, stock_client: strategy
+    )
+    monkeypatch.setattr(bot.time, "sleep", lambda x: None)
+
+    bot.main(poll_interval=0)
+
+    assert strategy.run.call_count == 1
+    assert trading.get_all_positions.call_count == 2


### PR DESCRIPTION
## Summary
- Loop strategy execution during market hours only
- Skip strategy when positions exist to prevent duplicates
- Add integration tests covering market hours and position checks

## Testing
- `pytest MKTONE/tests -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Bar' from partially initialized module 'alpaca.data')*

------
https://chatgpt.com/codex/tasks/task_e_68a57fa87228832d9f3dfc5549ec6d59