### PR TITLE
Use option chain mid prices for credit spreads

### DIFF
--- a/MKTONE/src/bot.py
+++ b/MKTONE/src/bot.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from .config import get_trading_client, get_stock_client
+from .config import get_option_client, get_stock_client, get_trading_client
 from .strategies.zero_dte_credit_spread import ZeroDTECreditSpread
 
 LOG_PATH = Path(__file__).resolve().parent.parent / "logs" / "bot.log"
@@ -17,7 +17,10 @@ logging.basicConfig(
 def main() -> None:
     trading = get_trading_client()
     stock = get_stock_client()
-    strategy = ZeroDTECreditSpread(trading_client=trading, stock_client=stock)
+    option = get_option_client()
+    strategy = ZeroDTECreditSpread(
+        trading_client=trading, stock_client=stock, option_client=option
+    )
     strategy.run()
 
 

--- a/MKTONE/src/bot.py
+++ b/MKTONE/src/bot.py
@@ -1,6 +1,7 @@
 """Entry point for running the MKTONE bot."""
 
 import logging
+import time
 from pathlib import Path
 
 from .config import get_option_client, get_stock_client, get_trading_client
@@ -14,14 +15,21 @@ logging.basicConfig(
 )
 
 
-def main() -> None:
+def main(poll_interval: float = 60) -> None:
     trading = get_trading_client()
     stock = get_stock_client()
     option = get_option_client()
     strategy = ZeroDTECreditSpread(
         trading_client=trading, stock_client=stock, option_client=option
     )
-    strategy.run()
+
+    while True:
+        clock = trading.get_clock()
+        if not clock.is_open:
+            break
+        if not trading.get_all_positions():
+            strategy.run()
+        time.sleep(poll_interval)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_zero_dte_credit_spread.py
+++ b/tests/test_zero_dte_credit_spread.py
@@ -1,0 +1,52 @@
+import datetime as dt
+from types import SimpleNamespace
+
+from MKTONE.src.strategies.zero_dte_credit_spread import (
+    ZeroDTECreditSpread,
+    build_option_symbol,
+)
+
+
+class DummyQuoteClient:
+    def __init__(self, data):
+        self.data = data
+
+    def get_option_chain(self, req):  # noqa: D401 - simple stub
+        return self.data
+
+
+def _make_chain(symbol: str, exp: dt.date, short: float, long: float):
+    short_symbol = build_option_symbol(symbol, exp, short, "P")
+    long_symbol = build_option_symbol(symbol, exp, long, "P")
+    chain = {
+        short_symbol: SimpleNamespace(
+            latest_quote=SimpleNamespace(bid_price=1.0, ask_price=1.2)
+        ),
+        long_symbol: SimpleNamespace(
+            latest_quote=SimpleNamespace(bid_price=0.5, ask_price=0.7)
+        ),
+    }
+    return chain, short_symbol, long_symbol
+
+
+def test_limit_price_matches_mid_quotes():
+    exp = dt.date.today()
+    chain, _, _ = _make_chain("SPY", exp, 100, 99)
+    option_client = DummyQuoteClient(chain)
+
+    strat = ZeroDTECreditSpread(
+        trading_client=None,
+        stock_client=None,
+        option_client=option_client,
+        strike_width=1.0,
+    )
+
+    strat._latest_price = lambda: 100  # price rounded to 100
+    strat._determine_direction = lambda: "bull"
+
+    order = strat._create_order()
+
+    expected_credit = (1.1 - 0.6)  # mid(short) - mid(long)
+    assert order.limit_price == -expected_credit
+    assert strat.profit_target_amt == expected_credit * strat.profit_target
+    assert strat.stop_loss_amt == expected_credit * strat.stop_loss


### PR DESCRIPTION
## Summary
- fetch mid prices from option chain to price credit spread orders
- calculate profit target and stop loss from credit
- supply option client to bot and test pricing logic

## Testing
- `pytest tests/test_zero_dte_credit_spread.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Bar' from partially initialized module 'alpaca.data')*


------
https://chatgpt.com/codex/tasks/task_e_68a57fa21fbc832d9cd9d9c985ef28df